### PR TITLE
feat: Add release notes to deployments

### DIFF
--- a/.github/workflows/android_cicd.yml
+++ b/.github/workflows/android_cicd.yml
@@ -45,11 +45,12 @@ jobs:
 
       - name: Create Release Notes
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
-          NOTES="${{ github.event.head_commit.message }}"
-          echo "$NOTES" > release_notes.txt
+          echo "$COMMIT_MESSAGE" > release_notes.txt
           mkdir -p whatsnew/en-US
-          echo "$NOTES" > whatsnew/en-US/default.txt
+          echo "$COMMIT_MESSAGE" > whatsnew/en-US/default.txt
 
       - name: Upload to Firebase App Distribution (Internal)
         if: github.ref == 'refs/heads/develop' && github.event_name == 'push'


### PR DESCRIPTION
This commit updates the CI/CD workflow to automatically include release notes in deployments.

- For pushes to `master`, the commit message is used to create release notes for both Firebase App Distribution and the Google Play Store's "what's new" section.
- For pushes to `develop`, the commit message is now included as release notes for the Firebase App Distribution build.