### PR TITLE
feat: Update CI/CD trigger branches

### DIFF
--- a/.github/workflows/android_cicd.yml
+++ b/.github/workflows/android_cicd.yml
@@ -10,8 +10,8 @@ on:
 
 jobs:
   build:
+    name: Build & Test
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -42,17 +42,8 @@ jobs:
           GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_WEB_CLIENT_ID }}
         run: ./gradlew app:bundleRelease
 
-      - name: Write Google Services credentials to file
+      - name: Write Firebase Service Account
         run: echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT_KEY }}' > ${{ github.workspace }}/service-account.json
-
-      - name: Create Release Notes
-        if: github.ref == 'refs/heads/trunk' && github.event_name == 'push'
-        env:
-          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-        run: |
-          echo "$COMMIT_MESSAGE" > release_notes.txt
-          mkdir -p whatsnew/en-US
-          echo "$COMMIT_MESSAGE" > whatsnew/en-US/default.txt
 
       - name: Upload to Firebase App Distribution (Internal)
         if: startsWith(github.ref, 'refs/heads/feature/') && github.event_name == 'push'
@@ -63,22 +54,66 @@ jobs:
           file: app/build/outputs/bundle/release/app-release.aab
           groups: internal-testers
 
-      - name: Upload to Firebase App Distribution (Beta)
+      - name: Upload App Bundle Artifact
+        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/trunk'
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-bundle
+          path: app/build/outputs/bundle/release/app-release.aab
+          retention-days: 1
+
+      - name: Create Release Notes
         if: github.ref == 'refs/heads/trunk' && github.event_name == 'push'
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        run: |
+          echo "$COMMIT_MESSAGE" > release_notes.txt
+          mkdir -p whatsnew/en-US
+          echo "$COMMIT_MESSAGE" > whatsnew/en-US/default.txt
+
+      - name: Upload Release Notes Artifact
+        if: github.ref == 'refs/heads/trunk' && github.event_name == 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-notes
+          path: |
+            release_notes.txt
+            whatsnew/
+          retention-days: 1
+
+  deploy:
+    name: Deploy to Production Channels
+    needs: build
+    if: github.ref == 'refs/heads/trunk' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download App Bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: app-bundle
+
+      - name: Download Release Notes
+        uses: actions/download-artifact@v4
+        with:
+          name: release-notes
+
+      - name: Write Firebase Service Account
+        run: echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT_KEY }}' > ${{ github.workspace }}/service-account.json
+
+      - name: Upload to Firebase App Distribution (Beta)
         uses: wzieba/Firebase-Distribution-Github-Action@v1
         with:
           appId: ${{ secrets.FIREBASE_APP_ID }}
           serviceCredentialsFile: ${{ github.workspace }}/service-account.json
-          file: app/build/outputs/bundle/release/app-release.aab
+          file: app-release.aab
           groups: beta-testers
           releaseNotesFile: release_notes.txt
 
       - name: Deploy to Google Play Internal Testing
-        if: github.ref == 'refs/heads/trunk' && github.event_name == 'push'
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_KEY }}
           packageName: com.eysamarin.squadplay
-          releaseFiles: app/build/outputs/bundle/release/app-release.aab
+          releaseFiles: app-release.aab
           track: internal
           whatsNewDirectory: whatsnew/

--- a/.github/workflows/android_cicd.yml
+++ b/.github/workflows/android_cicd.yml
@@ -2,9 +2,11 @@ name: Android CI/CD
 
 on:
   push:
-    branches: [ "develop", "master" ]
+    branches:
+      - 'trunk'
+      - 'feature/**'
   pull_request:
-    branches: [ "develop", "master" ]
+    branches: [ 'trunk' ]
 
 jobs:
   build:
@@ -44,7 +46,7 @@ jobs:
         run: echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT_KEY }}' > ${{ github.workspace }}/service-account.json
 
       - name: Create Release Notes
-        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/trunk' && github.event_name == 'push'
         env:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
@@ -53,7 +55,7 @@ jobs:
           echo "$COMMIT_MESSAGE" > whatsnew/en-US/default.txt
 
       - name: Upload to Firebase App Distribution (Internal)
-        if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
+        if: startsWith(github.ref, 'refs/heads/feature/') && github.event_name == 'push'
         uses: wzieba/Firebase-Distribution-Github-Action@v1
         with:
           appId: ${{ secrets.FIREBASE_APP_ID }}
@@ -62,7 +64,7 @@ jobs:
           groups: internal-testers
 
       - name: Upload to Firebase App Distribution (Beta)
-        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/trunk' && github.event_name == 'push'
         uses: wzieba/Firebase-Distribution-Github-Action@v1
         with:
           appId: ${{ secrets.FIREBASE_APP_ID }}
@@ -72,7 +74,7 @@ jobs:
           releaseNotesFile: release_notes.txt
 
       - name: Deploy to Google Play Internal Testing
-        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/trunk' && github.event_name == 'push'
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/android_cicd.yml
+++ b/.github/workflows/android_cicd.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    name: Build & Test
+    name: build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,7 +3,6 @@ import java.util.Properties
 
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.google.gms.google.services)
     alias(libs.plugins.google.firebase.crashlytics)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.eysamarin.squadplay"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 7
-        versionName = "0.7"
+        versionCode = 8
+        versionName = "0.8"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,7 +25,7 @@ android {
         applicationId = "com.eysamarin.squadplay"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 8
+        versionCode = 9
         versionName = "0.8"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.jetbrains.kotlin.jvm) apply false
     alias(libs.plugins.google.gms.google.services) apply false

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
 }
 
 android {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ android-minSdk = "28"
 #noinspection UnusedVersionCatalogEntry
 android-targetSdk = "36"
 
-agp = "8.13.2"
+agp = "9.0.0"
 kotlin = "2.3.0"
 kotlinxSerialization = "1.9.0"
 orgJetbrainsKotlinxCoroutinesCore = "1.10.2"
@@ -16,10 +16,10 @@ junitVersion = "1.3.0"
 lifecycleRuntimeKtx = "2.10.0"
 activityCompose = "1.12.2"
 navigationCompose = "2.9.6"
-composeBom = "2025.12.01"
+composeBom = "2026.01.00"
 jetbrainsKotlinJvm = "2.3.0"
 koin = "4.1.1"
-firebaseBom = "34.7.0"
+firebaseBom = "34.8.0"
 googleGmsGoogleServices = "4.4.4"
 googleFirebaseCrashlytics = "3.0.6"
 credentials = "1.5.0"
@@ -71,7 +71,6 @@ org-jetbrains-kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", na
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "jetbrainsKotlinJvm" }
 google-gms-google-services = { id = "com.google.gms.google-services", version.ref = "googleGmsGoogleServices" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Mar 07 19:01:00 CET 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This commit updates the CI/CD workflow triggers to align with the new branching strategy.

- The `push` and `pull_request` triggers are changed from `develop` and `master` to `trunk` and `feature/**`.
- Deployment steps for Firebase and Google Play are updated to trigger on pushes to `trunk` instead of `master`.
- The internal Firebase distribution now triggers on pushes to `feature/**` branches instead of `develop`.