### PR TITLE
53: Highlight user-created events in the calendar

### DIFF
--- a/app/src/main/kotlin/com/eysamarin/squadplay/screens/main/HomeScreenViewModel.kt
+++ b/app/src/main/kotlin/com/eysamarin/squadplay/screens/main/HomeScreenViewModel.kt
@@ -114,7 +114,11 @@ class HomeScreenViewModel(
         ) { userInfo, calendar, events ->
             userInfo ?: return@combine null
 
-            val eventBasedCalendar = calendarUIProvider.mergedCalendarWithEvents(calendar, events)
+            val eventBasedCalendar = calendarUIProvider.mergedCalendarWithEvents(
+                calendar = calendar,
+                events = events,
+                currentUserId = userInfo.uid
+            )
 
             val selectedDate = eventBasedCalendar.dates.firstOrNull { it.isSelected }
             val eventsBySelectedDate = events.filter {

--- a/app/src/main/kotlin/com/eysamarin/squadplay/ui/calendar/Calendar.kt
+++ b/app/src/main/kotlin/com/eysamarin/squadplay/ui/calendar/Calendar.kt
@@ -11,8 +11,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Badge
-import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -203,45 +203,21 @@ fun ContentItem(
     onItemTap: (Date) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+
     Box(
         modifier = modifier
-            .clip(SquircleShape(cornerSmoothing = CornerSmoothing.Small))
-            .background(color = if (date.isSelected) MaterialTheme.colorScheme.primary else Color.Transparent)
             .clickable(enabled = date.enabled) {
                 onItemTap(date)
-            }
-    ) {
-        BadgedBox(
-            modifier = Modifier
-                .align(Alignment.Center)
-                .padding(vertical = 12.dp),
-            badge = {
-                if (date.countEvents > 0) {
-                    Badge(
-                        modifier = Modifier.offset(x = 10.dp, y = (-8).dp),
-                        containerColor = when {
-                            !date.enabled -> MaterialTheme.colorScheme.outlineVariant
-                            date.isSelected -> MaterialTheme.colorScheme.onPrimary
-                            else -> MaterialTheme.colorScheme.primary
-                        },
-                        contentColor = when {
-                            !date.enabled -> MaterialTheme.colorScheme.surface
-                            date.isSelected -> MaterialTheme.colorScheme.primary
-                            else -> MaterialTheme.colorScheme.onPrimary
-                        }
-
-                    ) {
-                        Text(
-                            text = date.countEvents.toString(),
-                            style = adaptiveLabelByHeight(windowSize)
-                        )
-                    }
-                }
             },
+    ) {
+        Box(
+            modifier = Modifier
+                .clip(SquircleShape(cornerSmoothing = CornerSmoothing.Small))
+                .background(color = if (date.isSelected) MaterialTheme.colorScheme.primary else Color.Transparent)
+                .size(48.dp),
+            contentAlignment = Alignment.Center,
         ) {
-            
             Text(
-                modifier = Modifier,
                 text = date.dayOfMonth?.toString() ?: "",
                 color = when {
                     !date.enabled -> MaterialTheme.colorScheme.outlineVariant
@@ -250,6 +226,40 @@ fun ContentItem(
                 },
                 style = adaptiveBodyByHeight(windowSize),
             )
+
+        }
+
+        if (date.countEvents > 0) {
+            Badge(
+                modifier = Modifier.align(Alignment.TopEnd).offset(6.dp, (-6).dp),
+                containerColor = when {
+                    !date.enabled -> MaterialTheme.colorScheme.outlineVariant
+                    date.isSelected -> MaterialTheme.colorScheme.onPrimary
+                    else -> MaterialTheme.colorScheme.primary
+                },
+                contentColor = when {
+                    !date.enabled -> MaterialTheme.colorScheme.surface
+                    date.isSelected -> MaterialTheme.colorScheme.primary
+                    else -> MaterialTheme.colorScheme.onPrimary
+                }
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.padding(4.dp)
+                ) {
+                    if (date.hasUserEvents) {
+                        Text(
+                            text = "★",
+                            style = adaptiveLabelByHeight(windowSize),
+                            modifier = Modifier.padding(end = 2.dp)
+                        )
+                    }
+                    Text(
+                        text = date.countEvents.toString(),
+                        style = adaptiveLabelByHeight(windowSize)
+                    )
+                }
+            }
         }
     }
 }

--- a/domain/src/main/java/com/eysamarin/squadplay/domain/calendar/CalendarUIProvider.kt
+++ b/domain/src/main/java/com/eysamarin/squadplay/domain/calendar/CalendarUIProvider.kt
@@ -12,7 +12,11 @@ import java.util.Locale
 interface CalendarUIProvider {
     fun provideCalendarUIBy(yearMonth: YearMonth): CalendarUI
     fun updateCalendarBySelectedDate(target: CalendarUI, selectedDate: Date): CalendarUI
-    fun mergedCalendarWithEvents(calendar: CalendarUI, events: List<Event>): CalendarUI
+    fun mergedCalendarWithEvents(
+        calendar: CalendarUI,
+        events: List<Event>,
+        currentUserId: String
+    ): CalendarUI
 }
 
 class CalendarUIProviderImpl: CalendarUIProvider {
@@ -33,18 +37,21 @@ class CalendarUIProviderImpl: CalendarUIProvider {
 
     override fun mergedCalendarWithEvents(
         calendar: CalendarUI,
-        events: List<Event>
+        events: List<Event>,
+        currentUserId: String
     ): CalendarUI = calendar.copy(
         dates = calendar.dates.map { date ->
-            date.copy(
-                countEvents = events.count { event ->
-                    val fromDayOfMonth = event.fromDateTime.dayOfMonth
-                    val fromMonthOfYear = event.fromDateTime.month.value
+            val eventsOnDate = events.filter { event ->
+                val fromDayOfMonth = event.fromDateTime.dayOfMonth
+                val fromMonthOfYear = event.fromDateTime.month.value
 
-                    val isSameDay = fromDayOfMonth == date.dayOfMonth
-                            && fromMonthOfYear == date.monthNumber
-                    isSameDay
-                },
+                val isSameDay = fromDayOfMonth == date.dayOfMonth
+                        && fromMonthOfYear == date.monthNumber
+                isSameDay
+            }
+            date.copy(
+                countEvents = eventsOnDate.count(),
+                hasUserEvents = eventsOnDate.any { it.creatorId == currentUserId }
             )
         },
     )

--- a/models/src/main/kotlin/com/eysamarin/squadplay/models/MainScreenModels.kt
+++ b/models/src/main/kotlin/com/eysamarin/squadplay/models/MainScreenModels.kt
@@ -36,6 +36,7 @@ data class Date(
     val countEvents: Int,
     val isSelected: Boolean,
     val enabled: Boolean,
+    val hasUserEvents: Boolean = false,
 ) {
     companion object {
         val Empty = Date(
@@ -44,6 +45,7 @@ data class Date(
             countEvents = 0,
             isSelected = false,
             enabled = false,
+            hasUserEvents = false,
         )
     }
 }
@@ -84,16 +86,16 @@ val PREVIEW_CALENDAR_UI = CalendarUI(
     dates = listOf(
         Date(1, 12, 0, isSelected = false, enabled = true),
         Date(2, 12, 0, isSelected = false, enabled = true),
-        Date(3, 12, 1, isSelected = false, enabled = true),
+        Date(3, 12, 1, isSelected = false, enabled = true, hasUserEvents = true),
         Date(4, 12, 0, isSelected = false, enabled = true),
         Date(5, 12, 0, isSelected = false, enabled = true),
-        Date(6, 12, 5, isSelected = true, enabled = true),
+        Date(6, 12, 99, isSelected = true, enabled = true, hasUserEvents = true),
         Date(7, 12, 0, isSelected = false, enabled = true),
         Date(8, 12, 0, isSelected = false, enabled = true),
         Date(9, 12, 0, isSelected = false, enabled = true),
         Date(10, 12, 0, isSelected = false, enabled = true),
         Date(11, 12, 0, isSelected = false, enabled = true),
-        Date(12, 12, 3, isSelected = false, enabled = true),
+        Date(12, 12, 3, isSelected = false, enabled = true, hasUserEvents = true),
         Date(13, 12, 0, isSelected = false, enabled = true),
         Date(14, 12, 0, isSelected = false, enabled = true),
         Date(15, 12, 0, isSelected = false, enabled = true),
@@ -107,7 +109,7 @@ val PREVIEW_CALENDAR_UI = CalendarUI(
         Date(23, 12, 0, isSelected = false, enabled = true),
         Date(24, 12, 0, isSelected = false, enabled = true),
         Date(25, 12, 0, isSelected = false, enabled = true),
-        Date(26, 12, 5, isSelected = false, enabled = true),
+        Date(26, 12, 5, isSelected = false, enabled = true, hasUserEvents = true),
         Date(27, 12, 0, isSelected = false, enabled = true),
         Date(28, 12, 0, isSelected = false, enabled = true),
         Date(29, 12, 1, isSelected = false, enabled = true),


### PR DESCRIPTION
This commit introduces a visual indicator (a star symbol) on calendar dates to signify events created by the current user.

Key Changes:

- **Domain Logic & Models:**
    - Updated the `Date` model to include a `hasUserEvents` boolean flag.
    - Enhanced `CalendarUIProvider` to identify if any events on a given date were created by the current user by comparing `creatorId` with `currentUserId`.
    - Updated `HomeScreenViewModel` to provide the current user's ID when merging events into the calendar.

- **UI Improvements:**
    - Refactored the calendar date cell to use a more flexible `Box` and `Badge` layout instead of `BadgedBox`.
    - Implemented a star (`★`) indicator within the date's badge when `hasUserEvents` is true.
    - Adjusted badge positioning and styling to ensure consistent alignment and visibility across different date states (selected vs. unselected).
    - Updated sample data to reflect the new model property.