### PR TITLE
Implement proper splash screen and auth redirection

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -97,6 +97,7 @@ dependencies {
 
     implementation(libs.io.insert.koin.compose)
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,7 +24,7 @@ android {
         applicationId = "com.eysamarin.squadplay"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 10
+        versionCode = 11
         versionName = "0.8"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:launchMode="singleInstance"
-            android:theme="@style/Theme.SquadPlay">
+            android:theme="@style/Theme.App.Starting">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/kotlin/com/eysamarin/squadplay/LaunchApplicationViewModel.kt
+++ b/app/src/main/kotlin/com/eysamarin/squadplay/LaunchApplicationViewModel.kt
@@ -3,15 +3,38 @@ package com.eysamarin.squadplay
 import android.os.Build
 import androidx.compose.runtime.mutableStateListOf
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.eysamarin.squadplay.domain.auth.AuthProvider
+import com.eysamarin.squadplay.navigation.Navigator
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 
-class LaunchApplicationViewModel : ViewModel() {
+class LaunchApplicationViewModel(
+    private val authProvider: AuthProvider,
+    private val navigator: Navigator,
+) : ViewModel() {
     val visiblePermissionDialogQueue = mutableStateListOf<String>()
+
+    private val _isLoading = MutableStateFlow(true)
+    val isLoading = _isLoading.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            if (authProvider.isUserExists()) {
+                navigator.navigateToHomeGraph()
+            }
+            _isLoading.value = false
+        }
+    }
 
     fun dismissPermissionDialog() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
             visiblePermissionDialogQueue.removeFirst()
         } else {
-            visiblePermissionDialogQueue.removeAt(visiblePermissionDialogQueue. lastIndex)
+            if (visiblePermissionDialogQueue.isNotEmpty()) {
+                visiblePermissionDialogQueue.removeAt(visiblePermissionDialogQueue.lastIndex)
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/eysamarin/squadplay/LaunchApplicationViewModel.kt
+++ b/app/src/main/kotlin/com/eysamarin/squadplay/LaunchApplicationViewModel.kt
@@ -6,14 +6,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.eysamarin.squadplay.domain.auth.AuthProvider
 import com.eysamarin.squadplay.navigation.Destination
-import com.eysamarin.squadplay.navigation.Navigator
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 class LaunchApplicationViewModel(
     private val authProvider: AuthProvider,
-    private val navigator: Navigator,
 ) : ViewModel() {
     val visiblePermissionDialogQueue = mutableStateListOf<String>()
 

--- a/app/src/main/kotlin/com/eysamarin/squadplay/LaunchApplicationViewModel.kt
+++ b/app/src/main/kotlin/com/eysamarin/squadplay/LaunchApplicationViewModel.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.eysamarin.squadplay.domain.auth.AuthProvider
+import com.eysamarin.squadplay.navigation.Destination
 import com.eysamarin.squadplay.navigation.Navigator
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -19,10 +20,13 @@ class LaunchApplicationViewModel(
     private val _isLoading = MutableStateFlow(true)
     val isLoading = _isLoading.asStateFlow()
 
+    private val _startDestination = MutableStateFlow<Destination>(Destination.AuthGraph)
+    val startDestination = _startDestination.asStateFlow()
+
     init {
         viewModelScope.launch {
             if (authProvider.isUserExists()) {
-                navigator.navigateToHomeGraph()
+                _startDestination.value = Destination.HomeGraph
             }
             _isLoading.value = false
         }

--- a/app/src/main/kotlin/com/eysamarin/squadplay/MainActivity.kt
+++ b/app/src/main/kotlin/com/eysamarin/squadplay/MainActivity.kt
@@ -12,6 +12,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
@@ -33,12 +34,14 @@ class MainActivity : ComponentActivity() {
 
     @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
+        val splashScreen = installSplashScreen()
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
             SquadPlayTheme {
                 val windowSize = calculateWindowSizeClass(this)
                 val viewModel: LaunchApplicationViewModel = koinViewModel()
+                splashScreen.setKeepOnScreenCondition { viewModel.isLoading.value }
                 val permissionDialogQueue = viewModel.visiblePermissionDialogQueue
 
                 val multiplePermissionResultLauncher = rememberLauncherForActivityResult(

--- a/app/src/main/kotlin/com/eysamarin/squadplay/MainActivity.kt
+++ b/app/src/main/kotlin/com/eysamarin/squadplay/MainActivity.kt
@@ -18,9 +18,12 @@ import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.eysamarin.squadplay.navigation.Destination
 import com.eysamarin.squadplay.navigation.SquadPlayNavigation
 import com.eysamarin.squadplay.ui.PermissionDialog
 import com.eysamarin.squadplay.ui.theme.SquadPlayTheme
@@ -41,7 +44,10 @@ class MainActivity : ComponentActivity() {
             SquadPlayTheme {
                 val windowSize = calculateWindowSizeClass(this)
                 val viewModel: LaunchApplicationViewModel = koinViewModel()
-                splashScreen.setKeepOnScreenCondition { viewModel.isLoading.value }
+                val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+                val startDestination by viewModel.startDestination.collectAsStateWithLifecycle()
+
+                splashScreen.setKeepOnScreenCondition { isLoading }
                 val permissionDialogQueue = viewModel.visiblePermissionDialogQueue
 
                 val multiplePermissionResultLauncher = rememberLauncherForActivityResult(
@@ -83,7 +89,9 @@ class MainActivity : ComponentActivity() {
                         )
                     }
 
-                SquadPlayNavigation(windowSize)
+                if (!isLoading) {
+                    SquadPlayNavigation(windowSize, startDestination)
+                }
             }
         }
     }
@@ -109,6 +117,9 @@ class MainActivity : ComponentActivity() {
 @Composable
 fun FinanceStocksNavigationPreview() {
     SquadPlayTheme {
-        SquadPlayNavigation(WindowSizeClass.calculateFromSize(DpSize(400.dp, 900.dp)))
+        SquadPlayNavigation(
+            windowSize = WindowSizeClass.calculateFromSize(DpSize(400.dp, 900.dp)),
+            startDestination = Destination.AuthGraph
+        )
     }
 }

--- a/app/src/main/kotlin/com/eysamarin/squadplay/SquadPlayApplication.kt
+++ b/app/src/main/kotlin/com/eysamarin/squadplay/SquadPlayApplication.kt
@@ -28,7 +28,6 @@ import com.eysamarin.squadplay.domain.resource.StringProviderImpl
 import com.eysamarin.squadplay.messaging.SnackbarProvider
 import com.eysamarin.squadplay.messaging.SnackbarProviderImpl
 import com.eysamarin.squadplay.navigation.DefaultNavigator
-import com.eysamarin.squadplay.navigation.Destination
 import com.eysamarin.squadplay.navigation.Navigator
 import com.eysamarin.squadplay.screens.auth.AuthScreenViewModel
 import com.eysamarin.squadplay.screens.event.NewEventScreenViewModel
@@ -98,7 +97,7 @@ class SquadPlayApplication : Application() {
         //endregion
 
         //region presentation
-        single<Navigator> { DefaultNavigator(startDestination = Destination.AuthGraph) }
+        single<Navigator> { DefaultNavigator() }
         single<SnackbarProvider> { SnackbarProviderImpl() }
         viewModelOf(::LaunchApplicationViewModel)
         viewModelOf(::HomeScreenViewModel)

--- a/app/src/main/kotlin/com/eysamarin/squadplay/navigation/Navigator.kt
+++ b/app/src/main/kotlin/com/eysamarin/squadplay/navigation/Navigator.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.receiveAsFlow
 
 interface Navigator {
-    val startDestination: Destination
     val navigationActions: Flow<NavigationAction>
 
     suspend fun navigate(destination: Destination, navOptions: NavOptionsBuilder.() -> Unit = {})
@@ -15,7 +14,7 @@ interface Navigator {
     suspend fun navigateUp()
 }
 
-class DefaultNavigator(override val startDestination: Destination) : Navigator {
+class DefaultNavigator : Navigator {
     private val _navigationActions = Channel<NavigationAction>()
     override val navigationActions = _navigationActions.receiveAsFlow()
 

--- a/app/src/main/kotlin/com/eysamarin/squadplay/navigation/SquadPlayNavigation.kt
+++ b/app/src/main/kotlin/com/eysamarin/squadplay/navigation/SquadPlayNavigation.kt
@@ -54,7 +54,10 @@ import org.koin.compose.koinInject
 import kotlin.reflect.typeOf
 
 @Composable
-fun SquadPlayNavigation(windowSize: WindowSizeClass) {
+fun SquadPlayNavigation(
+    windowSize: WindowSizeClass,
+    startDestination: Destination,
+) {
 
     val navController = rememberNavController()
     val navigator = koinInject<Navigator>()
@@ -80,7 +83,7 @@ fun SquadPlayNavigation(windowSize: WindowSizeClass) {
 
     NavHost(
         navController = navController,
-        startDestination = navigator.startDestination
+        startDestination = startDestination
     ) {
         navigation<Destination.AuthGraph>(startDestination = Destination.AuthScreen) {
             composable<Destination.AuthScreen> {

--- a/app/src/main/kotlin/com/eysamarin/squadplay/screens/auth/AuthScreenViewModel.kt
+++ b/app/src/main/kotlin/com/eysamarin/squadplay/screens/auth/AuthScreenViewModel.kt
@@ -19,18 +19,6 @@ class AuthScreenViewModel(
     private val stringProvider: StringProvider,
 ) : ViewModel() {
 
-    init {
-        checkUserSignedIn()
-    }
-
-    private fun checkUserSignedIn() = viewModelScope.launch {
-        val isUserExists = authProvider.isUserExists()
-
-        if (isUserExists) {
-            navigator.navigateToHomeGraph()
-        }
-    }
-
     fun onSignInWithGoogleTap() = viewModelScope.launch {
         Log.d("TAG", "onSignUpTap")
         val isSuccess = authProvider.signInWithGoogle()

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="splashBackground">#FFF8F7</color>
+    <color name="splashBackground">#1C1012</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="primaryLight">#AE234C</color>
+    <color name="backgroundLight">#FFF8F7</color>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,4 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.SquadPlay" parent="Theme.AppCompat.DayNight" />
+    <style name="Theme.SquadPlay" parent="Theme.AppCompat.DayNight">
+        <item name="android:windowBackground">@color/backgroundLight</item>
+    </style>
+
+    <style name="Theme.App.Starting" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">@color/backgroundLight</item>
+        <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher</item>
+        <item name="postSplashScreenTheme">@style/Theme.SquadPlay</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="Theme.SquadPlay" parent="Theme.AppCompat.DayNight">
-        <item name="android:windowBackground">@color/backgroundLight</item>
+        <item name="android:windowBackground">@color/splashBackground</item>
     </style>
 
     <style name="Theme.App.Starting" parent="Theme.SplashScreen">
-        <item name="windowSplashScreenBackground">@color/backgroundLight</item>
+        <item name="windowSplashScreenBackground">@color/splashBackground</item>
         <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher</item>
         <item name="postSplashScreenTheme">@style/Theme.SquadPlay</item>
     </style>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ kotlin = "2.3.21"
 kotlinxSerialization = "1.11.0"
 orgJetbrainsKotlinxCoroutinesCore = "1.10.2"
 coreKtx = "1.18.0"
+coreSplashscreen = "1.2.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 lifecycleRuntimeKtx = "2.10.0"
@@ -33,6 +34,7 @@ comGoogleAndroidGmsOssLicenses = "17.5.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "coreSplashscreen" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }


### PR DESCRIPTION
This PR implements a proper splash screen using the SplashScreen API and handles automatic redirection to the Home screen if the user is already logged in, as requested in issue #51.

Changes:
- Added `androidx.core:core-splashscreen` dependency.
- Created `Theme.App.Starting` splash screen theme in `themes.xml`.
- Updated `MainActivity` to use the new splash screen theme and the SplashScreen API.
- Modified `LaunchApplicationViewModel` to check if a user exists and navigate to the Home screen if so.
- Incremented `versionCode` to 11.