### PR TITLE
[add-commit-skill] Add Gitflow Commit Formatter Skill

### DIFF
--- a/.agents/skills/gitflow-commit-formatter/SKILL.md
+++ b/.agents/skills/gitflow-commit-formatter/SKILL.md
@@ -1,31 +1,39 @@
 ---
 name: gitflow-commit-formatter
-description: Formats git commit messages with branch-based prefixes and Conventional Commits types. Use this for all commits in this project.
+description: Formats git commit messages with branch-based prefixes and Conventional Commits types. Use this for all commits in the project.
 ---
 
 # Gitflow Commit Formatter Skill
 
-When generating a git commit message, you MUST follow this specific format to maintain consistency with our Gitflow and issue-tracking practices.
+When generating a git commit message, you MUST follow this specific format to maintain consistency with Gitflow and issue-tracking practices.
 
 ## Format
 `[branch-name] <type>(<scope>): <description>`
 
 ## Instructions
 1. **Identify the Branch Name**: Get the name of the current git branch.
-2. **Prefix**: Wrap the branch name in square brackets at the very beginning of the commit title (e.g., `[feature/SP-123]`). 
-   - *Tip*: If the branch name is long, focus on the part containing the issue ID.
-3. **Type**: Use one of the standard Conventional Commits types:
+2. **Clean Branch Name**: Remove category prefixes like `feature/`, `bugfix/`, `hotfix/`, or `release/` from the branch name. Use only the descriptive part or issue ID (e.g., if branch is `feature/SP-123`, use `SP-123`).
+3. **Prefix**: Wrap the cleaned branch name in square brackets at the very beginning of the commit title (e.g., `[SP-123]`).
+4. **Type**: Use one of the standard Conventional Commits types:
    - `feat`: New feature
    - `fix`: Bug fix
    - `docs`: Documentation
-   - `style`: Formatting, whitespace, missing semi-colons, etc.
+   - `style`: Formatting, whitespace, missing semicolons, etc.
    - `refactor`: Code change that neither fixes a bug nor adds a feature
    - `perf`: Performance improvements
    - `test`: Adding missing tests or correcting existing tests
    - `chore`: Changes to the build process or auxiliary tools
-4. **Scope**: (Optional) Add a scope in parentheses if the change is specific to a module or component (e.g., `app`, `data`, `theme`).
-5. **Description**: Use the imperative mood, present tense (e.g., "add feature", "fix bug"). Do not capitalize the first letter and do not end with a period.
+5. **Scope**: (Optional) Add a scope in parentheses if the change is specific to a module or component (e.g., `app`, `data`, `theme`).
+6. **Description**: Use the imperative mood, present tense (e.g., "add feature", "fix bug"). Do not capitalize the first letter and do not end with a period.
+7. **Breaking Changes**: If the changes break backward compatibility, you MUST:
+   - Add a `!` after the type/scope (e.g., `feat(api)!: remove deprecated endpoint`).
+   - Add a footer starting with `BREAKING CHANGE: ` followed by a description of what was changed and how to migrate.
+8. **Atomic Commits**: Every commit MUST be atomic, meaning it should contain only one logical change or fix.
+9. **Analyze and Propose**:
+   - Before generating the message, analyze all changed files and the specific modifications within them at the line level.
+   - If changes (even within the same file) span multiple unrelated logical features or fixes, you MUST explicitly ask the user: *"I've detected multiple distinct changes. Do you want to include them all in one commit, or should I help you split them into separate atomic commits using Android Studio's line-level staging?"*
+   - If the user prefers to split, propose a clear plan specifying which logical blocks or lines should be staged for each commit (e.g., "Commit 1 (Fix in repository): [branch] fix(data): ..., Commit 2 (New field in model): [branch] feat(models): ...").
 
 ## Example
-`[feature/login-fix] fix(auth): resolve null pointer in social login`
+`[login-fix] fix(auth): resolve null pointer in social login`
 `[SP-456] feat(ui): add warm color scheme to theme`

--- a/.agents/skills/gitflow-commit-formatter/SKILL.md
+++ b/.agents/skills/gitflow-commit-formatter/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: gitflow-commit-formatter
+description: Formats git commit messages with branch-based prefixes and Conventional Commits types. Use this for all commits in this project.
+---
+
+# Gitflow Commit Formatter Skill
+
+When generating a git commit message, you MUST follow this specific format to maintain consistency with our Gitflow and issue-tracking practices.
+
+## Format
+`[branch-name] <type>(<scope>): <description>`
+
+## Instructions
+1. **Identify the Branch Name**: Get the name of the current git branch.
+2. **Prefix**: Wrap the branch name in square brackets at the very beginning of the commit title (e.g., `[feature/SP-123]`). 
+   - *Tip*: If the branch name is long, focus on the part containing the issue ID.
+3. **Type**: Use one of the standard Conventional Commits types:
+   - `feat`: New feature
+   - `fix`: Bug fix
+   - `docs`: Documentation
+   - `style`: Formatting, whitespace, missing semi-colons, etc.
+   - `refactor`: Code change that neither fixes a bug nor adds a feature
+   - `perf`: Performance improvements
+   - `test`: Adding missing tests or correcting existing tests
+   - `chore`: Changes to the build process or auxiliary tools
+4. **Scope**: (Optional) Add a scope in parentheses if the change is specific to a module or component (e.g., `app`, `data`, `theme`).
+5. **Description**: Use the imperative mood, present tense (e.g., "add feature", "fix bug"). Do not capitalize the first letter and do not end with a period.
+
+## Example
+`[feature/login-fix] fix(auth): resolve null pointer in social login`
+`[SP-456] feat(ui): add warm color scheme to theme`

--- a/.github/workflows/android_cicd.yml
+++ b/.github/workflows/android_cicd.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - 'trunk'
       - 'feature/**'
+    tags:
+      - 'v*'
   pull_request:
     branches: [ 'trunk' ]
 
@@ -40,7 +42,7 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           FIREBASE_DATABASE_URL: ${{ secrets.FIREBASE_DATABASE_URL }}
           GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_WEB_CLIENT_ID }}
-        run: ./gradlew app:bundleRelease
+        run: ./gradlew app:bundleRelease app:assembleRelease
 
       - name: Create Release Notes
         env:
@@ -64,15 +66,23 @@ jobs:
           releaseNotesFile: release_notes.txt
 
       - name: Upload App Bundle Artifact
-        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/trunk'
+        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/trunk' || startsWith(github.ref, 'refs/tags/v')
         uses: actions/upload-artifact@v4
         with:
           name: app-bundle
           path: app/build/outputs/bundle/release/app-release.aab
           retention-days: 1
 
+      - name: Upload APK Artifact
+        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/trunk' || startsWith(github.ref, 'refs/tags/v')
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-apk
+          path: app/build/outputs/apk/release/app-release.apk
+          retention-days: 1
+
       - name: Upload Release Notes Artifact
-        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/trunk' || startsWith(github.ref, 'refs/heads/feature/')
+        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/trunk' || startsWith(github.ref, 'refs/heads/feature/') || startsWith(github.ref, 'refs/tags/v')
         uses: actions/upload-artifact@v4
         with:
           name: release-notes
@@ -117,3 +127,32 @@ jobs:
           releaseFiles: app-release.aab
           track: internal
           whatsNewDirectory: whatsnew/
+
+  github-release:
+    name: Create GitHub Release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download App Bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: app-bundle
+
+      - name: Download APK
+        uses: actions/download-artifact@v4
+        with:
+          name: app-apk
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            app-release.aab
+            app-release.apk
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+

--- a/.github/workflows/android_cicd.yml
+++ b/.github/workflows/android_cicd.yml
@@ -155,4 +155,3 @@ jobs:
           draft: false
           prerelease: false
           generate_release_notes: true
-

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SquadPlay 🎮
+# SquadPlay 🎮 by Evgeny Samarin
 
 [![LinkedIn](https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555)](https://linkedin.com/in/evgenysamarin)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,7 +24,7 @@ android {
         applicationId = "com.eysamarin.squadplay"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 11
+        versionCode = 12
         versionName = "0.8"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
This PR adds a new skill for Antigravity CLI to format commit messages according to Gitflow and Conventional Commits practices. It also increments the app version code as per project rules.